### PR TITLE
Update to avr-device 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-avr-device = { version = "0.3", features = ["atmega32u4"] }
+avr-device = { version = "0.4", features = ["atmega32u4"] }
 usb-device = "0.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ impl UsbBus {
             .filter(|&(_, ep)| ep.is_allocated)
     }
 
-    fn set_current_endpoint(&self, cs: &CriticalSection, index: usize) -> Result<(), UsbError> {
+    fn set_current_endpoint(&self, cs: CriticalSection, index: usize) -> Result<(), UsbError> {
         if index >= MAX_ENDPOINTS {
             return Err(UsbError::InvalidEndpoint);
         }
@@ -96,13 +96,13 @@ impl UsbBus {
         Ok(())
     }
 
-    fn endpoint_byte_count(&self, cs: &CriticalSection) -> u16 {
+    fn endpoint_byte_count(&self, cs: CriticalSection) -> u16 {
         let usb = self.usb.borrow(cs);
         // FIXME: Potential for desync here? LUFA doesn't seem to care.
         ((usb.uebchx.read().bits() as u16) << 8) | (usb.uebclx.read().bits() as u16)
     }
 
-    fn configure_endpoint(&self, cs: &CriticalSection, index: usize) -> Result<(), UsbError> {
+    fn configure_endpoint(&self, cs: CriticalSection, index: usize) -> Result<(), UsbError> {
         let usb = self.usb.borrow(cs);
         self.set_current_endpoint(cs, index)?;
         let endpoint = &self.endpoints[index];


### PR DESCRIPTION
Hi,

Once avr-device is updated to 0.4, there are some fixes to apply to make the lib work.
Tested on arduino pro micro.