### PR TITLE
lib: Add PLL enable/disable to UsbBus impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-avr-device = { version = "0.4", features = ["atmega32u4"] }
+avr-device = { version = "0.5", features = ["atmega32u4"] }
 usb-device = "0.2"
 
 [dev-dependencies]

--- a/examples/arduino_keyboard.rs
+++ b/examples/arduino_keyboard.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
 
     let usb_bus = unsafe {
         static mut USB_BUS: Option<UsbBusAllocator<UsbBus>> = None;
-        &*USB_BUS.insert(UsbBus::new(usb))
+        &*USB_BUS.insert(UsbBus::new(usb, pll))
     };
 
     let hid_class = HIDClass::new(&usb_bus, KeyboardReport::desc(), 1);

--- a/examples/arduino_keyboard.rs
+++ b/examples/arduino_keyboard.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
 
     let usb_bus = unsafe {
         static mut USB_BUS: Option<UsbBusAllocator<UsbBus>> = None;
-        &*USB_BUS.insert(UsbBus::new(usb, pll))
+        &*USB_BUS.insert(UsbBus::new_with_pll(usb, pll))
     };
 
     let hid_class = HIDClass::new(&usb_bus, KeyboardReport::desc(), 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use core::{cell::Cell, cmp::max};
 
 use avr_device::atmega32u4::{
     usb_device::{udint, ueintx, usbint, UDINT, UEINTX, USBINT},
-    USB_DEVICE,
+    PLL, USB_DEVICE,
 };
 use avr_device::interrupt::{self, CriticalSection, Mutex};
 use usb_device::{
@@ -59,15 +59,17 @@ impl EndpointTableEntry {
 
 pub struct UsbBus {
     usb: Mutex<USB_DEVICE>,
+    pll: Mutex<PLL>,
     pending_ins: Mutex<Cell<u8>>,
     endpoints: [EndpointTableEntry; MAX_ENDPOINTS],
     dpram_usage: u16,
 }
 
 impl UsbBus {
-    pub fn new(usb: USB_DEVICE) -> UsbBusAllocator<Self> {
+    pub fn new(usb: USB_DEVICE, pll: PLL) -> UsbBusAllocator<Self> {
         UsbBusAllocator::new(Self {
             usb: Mutex::new(usb),
+            pll: Mutex::new(pll),
             pending_ins: Mutex::new(Cell::new(0)),
             endpoints: Default::default(),
             dpram_usage: 0,
@@ -381,14 +383,17 @@ impl usb_device::bus::UsbBus for UsbBus {
             usb.udien
                 .modify(|_, w| w.wakeupe().set_bit().suspe().clear_bit());
             usb.usbcon.modify(|_, w| w.frzclk().set_bit());
-            //TODO disable PLL
+            let pll = self.pll.borrow(cs);
+            pll.pllcsr.modify(|_, w| w.plle().clear_bit());
         });
     }
 
     fn resume(&self) {
         interrupt::free(|cs| {
             let usb = self.usb.borrow(cs);
-            //TODO enable PLL
+            let pll = self.pll.borrow(cs);
+            pll.pllcsr
+                .modify(|_, w| w.pindiv().set_bit().plle().set_bit());
             usb.usbcon.modify(|_, w| w.frzclk().clear_bit());
             usb.udint
                 .clear_interrupts(|w| w.wakeupi().clear_bit().suspi().clear_bit());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ impl UsbBus {
         if usb.usbcon.read().frzclk().bit_is_set() {
             return Err(UsbError::InvalidState);
         }
-        usb.uenum.write(|w| unsafe { w.bits(index as u8) });
+        usb.uenum.write(|w| w.bits(index as u8));
         if usb.uenum.read().bits() & 0b111 != (index as u8) {
             return Err(UsbError::InvalidState);
         }
@@ -269,7 +269,7 @@ impl usb_device::bus::UsbBus for UsbBus {
                 }
 
                 for &byte in buf {
-                    usb.uedatx.write(|w| unsafe { w.bits(byte) })
+                    usb.uedatx.write(|w| w.bits(byte))
                 }
 
                 usb.ueintx.clear_interrupts(|w| w.txini().clear_bit());
@@ -285,7 +285,7 @@ impl usb_device::bus::UsbBus for UsbBus {
                     if usb.ueintx.read().rwal().bit_is_clear() {
                         return Err(UsbError::BufferOverflow);
                     }
-                    usb.uedatx.write(|w| unsafe { w.bits(byte) });
+                    usb.uedatx.write(|w| w.bits(byte));
                 }
 
                 //NB: RXOUTI serves as KILLBK for IN endpoints and needs to stay zero:


### PR DESCRIPTION
Adds `PLL` enable/disable to `UsbBus` impl, fixing the TODO comments.

Bumps `avr-device` to `0.5.x` to have consistent re-exports with `avr-hal`.

Minor changes for API differences in `avr-device`.