### PR TITLE
toolchain: fix rustup-toolchain to specific nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-03-24"


### PR DESCRIPTION
Uses the most recent version of nightly toolchain that compiles AVR targets.

A regression in LLVM causes rustc to fail when compiling AVR targets.

See: https://github.com/rust-lang/compiler-builtins/issues/523