### PR TITLE
lib: add a UsbBus::force_reset implementation

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2023-03-24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,6 +463,17 @@ impl usb_device::bus::UsbBus for UsbBus {
             PollResult::None
         })
     }
+
+    fn force_reset(&self) -> usb_device::Result<()> {
+        interrupt::free(|cs| {
+            self.usb
+                .borrow(cs)
+                .udcon
+                .modify(|_, w| w.detach().set_bit());
+
+            Ok(())
+        })
+    }
 }
 
 /// Extension trait for conveniently clearing AVR interrupt flag registers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
+#![feature(asm_experimental_arch)]
 
-use core::{cell::Cell, cmp::max};
+use core::{arch::asm, cell::Cell, cmp::max};
 
 use avr_device::atmega32u4::{
     usb_device::{udint, ueintx, usbint, UDINT, UEINTX, USBINT},
@@ -465,14 +466,29 @@ impl usb_device::bus::UsbBus for UsbBus {
     }
 
     fn force_reset(&self) -> usb_device::Result<()> {
+        // 22.9 "It is possible to re-enumerate a device, simply by setting and
+        // clearing the DETACH bit (but firmware must take in account a
+        // debouncing delay of some milliseconds)."
+
         interrupt::free(|cs| {
             self.usb
                 .borrow(cs)
                 .udcon
                 .modify(|_, w| w.detach().set_bit());
+        });
 
-            Ok(())
-        })
+        // Delay for at least 1ms (exactly 1ms at 16 MHz)
+        // to allow the host to detect the change.
+        delay_cycles(16000);
+
+        interrupt::free(|cs| {
+            self.usb
+                .borrow(cs)
+                .udcon
+                .modify(|_, w| w.detach().clear_bit());
+        });
+
+        Ok(())
     }
 }
 
@@ -534,5 +550,33 @@ impl ClearInterrupts for USBINT {
     {
         // Bits 7:1 are reserved as do not set.
         self.write(|w| f(unsafe { w.bits(0x01) }))
+    }
+}
+
+/// Placeholder for `avr_device::asm::delay_cycles`
+///
+/// https://github.com/Rahix/avr-device/pull/127
+#[inline(always)]
+fn delay_cycles(cycles: u32) {
+    let mut cycles_bytes = cycles.to_le_bytes();
+    // Each loop iteration takes 6 cycles when the branch is taken,
+    // and 5 cycles when the branch is not taken.
+    // So, this loop is guaranteed to run for at least `cycles - 1` cycles,
+    // and there will be approximately 4 cycles before the loop to initialize
+    // the counting registers.
+    unsafe {
+        asm!(
+            "1:",
+            "subi {r0}, 6",
+            "sbci {r1}, 0",
+            "sbci {r2}, 0",
+            "sbci {r3}, 0",
+            "brcc 1b",
+
+            r0 = inout(reg_upper) cycles_bytes[0],
+            r1 = inout(reg_upper) cycles_bytes[1],
+            r2 = inout(reg_upper) cycles_bytes[2],
+            r3 = inout(reg_upper) cycles_bytes[3],
+        )
     }
 }


### PR DESCRIPTION
Implements the `force_reset` function for `usb_device::UsbBus`, that simply sets the `UDCON::detach` bit.