### PR TITLE
fixup/example/arduino_keyboard: code cleanup + docs 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ impl UsbBus {
         if usb.usbcon.read().frzclk().bit_is_set() {
             return Err(UsbError::InvalidState);
         }
-        usb.uenum.write(|w| unsafe { w.bits(index as u8) });
+        usb.uenum.write(|w| w.bits(index as u8));
         if usb.uenum.read().bits() & 0b111 != (index as u8) {
             return Err(UsbError::InvalidState);
         }
@@ -267,7 +267,7 @@ impl usb_device::bus::UsbBus for UsbBus {
                 }
 
                 for &byte in buf {
-                    usb.uedatx.write(|w| unsafe { w.bits(byte) })
+                    usb.uedatx.write(|w| w.bits(byte))
                 }
 
                 usb.ueintx.clear_interrupts(|w| w.txini().clear_bit());
@@ -283,7 +283,7 @@ impl usb_device::bus::UsbBus for UsbBus {
                     if usb.ueintx.read().rwal().bit_is_clear() {
                         return Err(UsbError::BufferOverflow);
                     }
-                    usb.uedatx.write(|w| unsafe { w.bits(byte) });
+                    usb.uedatx.write(|w| w.bits(byte));
                 }
 
                 //NB: RXOUTI serves as KILLBK for IN endpoints and needs to stay zero:


### PR DESCRIPTION
Adds some documentation for running the example on hardware, like how to  pull the `trigger` pin low to start sending keyboard reports.

Adds a debouncer for slowing down keyboard report transmission. This helps with the host not seeing repeated letters as duplicate reports.

Closes #5 