### PR TITLE
Update usb-device to v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 avr-device = { version = "0.5", features = ["atmega32u4"] }
-usb-device = "0.2"
+usb-device = "0.3"
 
 [dev-dependencies]
-usbd-hid = "0.6"
+usbd-hid = "0.7"
 
 [dev-dependencies.arduino-hal]
 git = "https://github.com/Rahix/avr-hal.git"

--- a/examples/arduino_keyboard.rs
+++ b/examples/arduino_keyboard.rs
@@ -40,7 +40,9 @@ use atmega_usbd::{SuspendNotifier, UsbBus};
 use avr_device::{asm::sleep, interrupt};
 use usb_device::{
     class_prelude::UsbBusAllocator,
+    descriptor::lang_id::LangID,
     device::{UsbDevice, UsbDeviceBuilder, UsbVidPid},
+    prelude::StringDescriptors,
 };
 use usbd_hid::{
     descriptor::{KeyboardReport, SerializedDescriptor},
@@ -78,9 +80,12 @@ fn main() -> ! {
     };
 
     let hid_class = HIDClass::new(usb_bus, KeyboardReport::desc(), 1);
-    let usb_device = UsbDeviceBuilder::new(usb_bus, UsbVidPid(0x1209, 0x0001))
+    let strings = StringDescriptors::new(LangID::EN)
         .manufacturer("Foo")
-        .product("Bar")
+        .product("Bar");
+    let usb_device = UsbDeviceBuilder::new(usb_bus, UsbVidPid(0x1209, 0x0001))
+        .strings(&[strings])
+        .unwrap()
         .build();
 
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ impl<S: SuspendNotifier> usb_device::bus::UsbBus for UsbBus<S> {
         let entry = &mut self.endpoints[ep_addr.index()];
         entry.eptype_bits = match ep_type {
             EndpointType::Control => EP_TYPE_CONTROL,
-            EndpointType::Isochronous => EP_TYPE_ISOCHRONOUS,
+            EndpointType::Isochronous { .. } => EP_TYPE_ISOCHRONOUS,
             EndpointType::Bulk => EP_TYPE_BULK,
             EndpointType::Interrupt => EP_TYPE_INTERRUPT,
         };


### PR DESCRIPTION
The 0.3 version of usb-device comes with some incompatible changes, so a minor amount of migration is required. An update of usbd-hid is required for the same reason.